### PR TITLE
Add link to documentation about Attaching Files to Your Submission

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -31,9 +31,7 @@ To create a new submission:
     Click on the `Create Pull Request` button to create a new 
     submission.
 
-#### Attaching Files to Your Submission
-
-TBD
+#### [Attaching Files to Your Submission](https://help.github.com/en/articles/adding-a-file-to-a-repository)
 
 #### Adding the manuscript as part of your submission
 


### PR DESCRIPTION
Instead of writing instructions here I link to GitHub Help. Reusing GitHub documentation is one other way in which can benefit from GitHub.